### PR TITLE
Replaced enviornment by environment - using.md

### DIFF
--- a/docs/csi_driver/using.md
+++ b/docs/csi_driver/using.md
@@ -206,7 +206,7 @@ spec:
 ```
 
 !!! note
-    In most enviornments, there is a default `StorageClass` declared on the cluster. In such a scenario, the `.spec.storageClassName` can be omitted. The default `StorageClass` is controlled by an annotation: `.metadata.annotations.storageclass.kubernetes.io/is-default-class` set to either `"true"` or `"false"`.
+    In most environments, there is a default `StorageClass` declared on the cluster. In such a scenario, the `.spec.storageClassName` can be omitted. The default `StorageClass` is controlled by an annotation: `.metadata.annotations.storageclass.kubernetes.io/is-default-class` set to either `"true"` or `"false"`.
 
 After the `PersistentVolumeClaim` has been declared, check that a new `PersistentVolume` is created based on your claim:
 


### PR DESCRIPTION
Fixed a typo in using.md. Replaced enviornment by environment