### PR TITLE
Doc updates for v1.0.1 release

### DIFF
--- a/docs/container_storage_provider/hpe_3par_primera/index.md
+++ b/docs/container_storage_provider/hpe_3par_primera/index.md
@@ -13,7 +13,7 @@ Always check the corresponding CSI driver version in [compatibility and support]
 
 |  CSI   |   CSP  | Linux OS | OpenShift | Kubernetes | 3PAR and Primera OS |
 | ------ | ------ | -------- | --------- | ---------- | ------------------- |
-| v1.1.1 | v1.0.0 | - CentOS: 7.7 <br /> - RHEL: 7.6, 7.7 / RHCOS | OpenShift 4.2 with RHEL 7.6 or 7.7 or RHCOS as worker nodes| K8s 1.16, 1.17 | - 3PAR OS: 3.3.1 (FC & iSCSI) <br /> - Primera OS: 4.0.0, 4.1.0 (FC only) |
+| v1.2.0 | v1.0.1 | - CentOS: 7.7 <br /> - RHEL: 7.6, 7.7 / RHCOS | OpenShift 4.2/4.3 with RHEL 7.6 or 7.7 or RHCOS as worker nodes| K8s 1.16, 1.17, 1.18 | - 3PAR OS: 3.3.1 (FC & iSCSI) <br /> - Primera OS: 4.0.0, 4.1.0 (FC only) |
 
 !!! important
     • Minimum 2 iSCSI IP ports should be in ready state<br />
@@ -77,13 +77,14 @@ These parameters are used for volume provisioning and supported platforms.
 | --------------------------------- | ------- | ----------- | :--: | :-----: |
 | accessProtocol <br /> (required)    | fc      | The access protocol to use when accessing the persistent volume. | **X** | **X** |
 |                                     | iscsi   | The access protocol to use when accessing the persistent volume. | **X** |   |
-| cpg <br /> (required)               | Text    | The name of existing CPG to be used for volume provisioning. | **X** | **X** | 
+| cpg <br />                | Text    | The name of existing CPG to be used for volume provisioning. If this parameter is not specified, CSP autocomputes this value| **X** | **X** | 
 | snap_cpg                            | Text    | The name of the snapshot CPG to be used for volume provisioning. Defaults to value of `cpg` if not specified. | **X** | **X** |
 | compression                         | Boolean | Indicates that the volume should be compressed. | **X** |   |
-| provisioning_type <br /> (required) | tpvv    | Indicates Thin provisioned volume type. | **X** | **X** |
+| provisioning_type <br />  | tpvv    | Indicates Thin provisioned volume type. If this parameter is not specified, defaults to tpvv | **X** | **X** |
 |                                     | full    | Indicates Full provisioned volume type. | **X** |   |
 |                                     | dedup   | Indicates Thin Deduplication volume type. | **X** |   |
 |                                     | reduce  | Indicates Thin Deduplication/Compression volume type. |   | **X** |
+| importVol <br /> this is the only option required for importing volume    | Text      | Name of the volume to import via the StorageClass | **X** | **X** |
 
 !!! Important
     The HPE CSI Driver allows the `PersistentVolumeClaim` to override the `StorageClass` parameters by annotating the `PersistentVolumeClaim`. Please see [Using PVC Overrides](../../csi_driver/using.md#using_pvc_overrides) for more details.
@@ -136,7 +137,7 @@ These parameters are applicable only for Pod inline volumes and to be specified 
 | inline-volume-secret-name      | Text    | A reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume call.|
 | inline-volume-secret-namespace | Text    | The namespace of `inline-volume-secret-name` for ephemeral inline volume.|
 | size                           | Text    | The size of ephemeral volume specified in MiB or GiB. If unspecified, a default value will be used.|
-| accessProtocol                 | Text    | Storage access protocol to use, "iscsi" or "fc".
+| accessProtocol                 | Text    | Storage access protocol to use, "iscsi" or "fc".|
 
 !!! important
     All parameters are **required** for inline ephemeral volumes.

--- a/docs/container_storage_provider/hpe_3par_primera/index.md
+++ b/docs/container_storage_provider/hpe_3par_primera/index.md
@@ -77,10 +77,10 @@ These parameters are used for volume provisioning and supported platforms.
 | --------------------------------- | ------- | ----------- | :--: | :-----: |
 | accessProtocol <br /> (required)    | fc      | The access protocol to use when accessing the persistent volume. | **X** | **X** |
 |                                     | iscsi   | The access protocol to use when accessing the persistent volume. | **X** |   |
-| cpg <br />                | Text    | The name of existing CPG to be used for volume provisioning. If this parameter is not specified, CSP autocomputes this value| **X** | **X** | 
+| cpg <br />                | Text    | The name of existing CPG to be used for volume provisioning. If the cpg parameter is not specified, the CSP will automatically set cpg parameter based upon a CPG available to 3PAR or Primera array.| **X** | **X** | 
 | snap_cpg                            | Text    | The name of the snapshot CPG to be used for volume provisioning. Defaults to value of `cpg` if not specified. | **X** | **X** |
 | compression                         | Boolean | Indicates that the volume should be compressed. | **X** |   |
-| provisioning_type <br />  | tpvv    | Indicates Thin provisioned volume type. If this parameter is not specified, defaults to tpvv | **X** | **X** |
+| provisioning_type <br />  | tpvv    | Indicates Thin provisioned volume type. Default: tpvv | **X** | **X** |
 |                                     | full    | Indicates Full provisioned volume type. | **X** |   |
 |                                     | dedup   | Indicates Thin Deduplication volume type. | **X** |   |
 |                                     | reduce  | Indicates Thin Deduplication/Compression volume type. |   | **X** |


### PR DESCRIPTION
- Made `cpg`, `provisioning_type` to optional
- Added SPOCK updates
- Added `importVol` option in StorageClass parameters.