### PR TITLE
Mobilefixes

### DIFF
--- a/docs/css/hpedev.css
+++ b/docs/css/hpedev.css
@@ -145,10 +145,6 @@
   width: 310px;
 }
 
-.wy-nav-content-wrap {
-  /* margin-left: 310px; */
-}
-
 .rst-content .section ol li > ol, .rst-content .section ol li > ul, .rst-content .section ul li > ol, .rst-content .section ul li > ul, .rst-content .toctree-wrapper ol li > ol, .rst-content .toctree-wrapper ol li > ul, .rst-content .toctree-wrapper ul li > ol, .rst-content .toctree-wrapper ul li > ul, .rst-content section ol li > ol, .rst-content section ol li > ul, .rst-content section ul li > ol, .rst-content section ul li > ul, .rst-content .section ol li > *, .rst-content .section ul li > *, .rst-content .toctree-wrapper ol li > *, .rst-content .toctree-wrapper ul li > *, .rst-content section ol li > *, .rst-content section ul li > * {
 	margin-top: 0px;
 	margin-bottom: 0px;

--- a/docs/css/hpedev.css
+++ b/docs/css/hpedev.css
@@ -2,7 +2,7 @@
     background: #477083;
 }
 .wy-nav-side {
-/*    width: 300px;   */
+    width: 300px;
     background: #425563;
 }
 

--- a/docs/css/hpedev.css
+++ b/docs/css/hpedev.css
@@ -146,7 +146,7 @@
 }
 
 .wy-nav-content-wrap {
-  margin-left: 310px;
+  /* margin-left: 310px; */
 }
 
 .rst-content .section ol li > ol, .rst-content .section ol li > ul, .rst-content .section ul li > ol, .rst-content .section ul li > ul, .rst-content .toctree-wrapper ol li > ol, .rst-content .toctree-wrapper ol li > ul, .rst-content .toctree-wrapper ul li > ol, .rst-content .toctree-wrapper ul li > ul, .rst-content section ol li > ol, .rst-content section ol li > ul, .rst-content section ul li > ol, .rst-content section ul li > ul, .rst-content .section ol li > *, .rst-content .section ul li > *, .rst-content .toctree-wrapper ol li > *, .rst-content .toctree-wrapper ul li > *, .rst-content section ol li > *, .rst-content section ul li > * {

--- a/docs/css/hpedev.css
+++ b/docs/css/hpedev.css
@@ -2,7 +2,7 @@
     background: #477083;
 }
 .wy-nav-side {
-    width: 300px;
+/*    width: 300px;   */
     background: #425563;
 }
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,4 @@
-site_name: 'HPE Storage Container Orchestrator Documentation'
+site_name: 'scod.hpedev.io'
 site_description: 'Reference documentation for container orchestrator integration for HPE storage'
 site_url: 'https://scod.hpedev.io/'
 site_author: 'Hewlett Packard Enterprise'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,4 @@
-site_name: 'scod.hpedev.io'
+site_name: 'SCOD.HPEDEV.IO'
 site_description: 'Reference documentation for container orchestrator integration for HPE storage'
 site_url: 'https://scod.hpedev.io/'
 site_author: 'Hewlett Packard Enterprise'


### PR DESCRIPTION
Fixes for non-desktop browsers:
- A CSS issue prevented the new MKDocs to render properly on mobile devices.
- The site_name label caused double lines and wasn't very aesthetically pleasing