### PR TITLE
OpenShift 4.15 runtime

### DIFF
--- a/docs/csi_driver/examples/deployment/hpe-csi-operator.yaml
+++ b/docs/csi_driver/examples/deployment/hpe-csi-operator.yaml
@@ -9,6 +9,7 @@ spec:
     primera: false
     alletra6000: false
     alletra9000: false
+    alletraStorageMP: false
   imagePullPolicy: IfNotPresent
   logLevel: info
   disableNodeConformance: false

--- a/docs/partners/redhat_openshift/examples/scc/hpe-csi-scc.yaml
+++ b/docs/partners/redhat_openshift/examples/scc/hpe-csi-scc.yaml
@@ -60,7 +60,7 @@ apiVersion: security.openshift.io/v1
 metadata:
   name: hpe-csi-csp-scc
 allowHostDirVolumePlugin: true
-readOnlyRootFilesystem: true
+readOnlyRootFilesystem: false
 runAsUser:
   type: RunAsAny
 seLinuxContext:


### PR DESCRIPTION
Fix for the below on OpenShift 4.15:
```
Exception in thread "main" java.lang.RuntimeException: Failed to start quarkus
	at io.quarkus.runner.ApplicationImpl.doStart(ApplicationImpl.zig:275)
	at io.quarkus.runtime.Application.start(Application.java:87)
	at io.quarkus.runtime.Application.run(Application.java:210)
	at io.quarkus.runner.GeneratedMain.main(GeneratedMain.zig:41)
Caused by: java.lang.IllegalStateException: Failed to create cache dir
```