### PR TITLE
Change default on disableHostDeletion to true

### DIFF
--- a/docs/csi_driver/examples/deployment/hpecsidriver-v2.5.0-sample.yaml
+++ b/docs/csi_driver/examples/deployment/hpecsidriver-v2.5.0-sample.yaml
@@ -34,7 +34,7 @@ spec:
     alletraStorageMP: false
     nimble: false
     primera: false
-  disableHostDeletion: false
+  disableHostDeletion: true
   disableNodeConfiguration: false
   disableNodeConformance: false
   disableNodeGetVolumeStats: false

--- a/docs/csi_driver/examples/deployment/hpecsidriver-v2.5.1-sample.yaml
+++ b/docs/csi_driver/examples/deployment/hpecsidriver-v2.5.1-sample.yaml
@@ -34,7 +34,7 @@ spec:
     alletraStorageMP: false
     nimble: false
     primera: false
-  disableHostDeletion: false
+  disableHostDeletion: true
   disableNodeConfiguration: false
   disableNodeConformance: false
   disableNodeGetVolumeStats: false

--- a/docs/csi_driver/examples/deployment/hpecsidriver-v2.5.2-sample.yaml
+++ b/docs/csi_driver/examples/deployment/hpecsidriver-v2.5.2-sample.yaml
@@ -34,7 +34,7 @@ spec:
     alletraStorageMP: false
     nimble: false
     primera: false
-  disableHostDeletion: false
+  disableHostDeletion: true
   disableNodeConfiguration: false
   disableNodeConformance: false
   disableNodeGetVolumeStats: false

--- a/docs/csi_driver/examples/deployment/hpecsidriver-v3.0.0-sample.yaml
+++ b/docs/csi_driver/examples/deployment/hpecsidriver-v3.0.0-sample.yaml
@@ -35,7 +35,7 @@ spec:
     b10000FileService: false
     nimble: false
     primera: false
-  disableHostDeletion: false
+  disableHostDeletion: true
   disableNodeConfiguration: false
   disableNodeConformance: false
   disableNodeGetVolumeStats: false

--- a/docs/csi_driver/examples/deployment/hpecsidriver-v3.0.1-sample.yaml
+++ b/docs/csi_driver/examples/deployment/hpecsidriver-v3.0.1-sample.yaml
@@ -35,7 +35,7 @@ spec:
     b10000FileService: false
     nimble: false
     primera: false
-  disableHostDeletion: false
+  disableHostDeletion: true
   disableNodeConfiguration: false
   disableNodeConformance: false
   disableNodeGetVolumeStats: false


### PR DESCRIPTION
Currently the example yaml disables host deletion which causes hosts to disappear from a Kubernetes cluster if the host does not have volumes attached.

Administrators then need to manually re-add the host to make it available to the cluster again.

This commit changes this behaviour to a more user-friendly default.