### PR TITLE
docs: Add documentation for new COSI driver parameters

### DIFF
--- a/docs/cosi_driver/deployment.md
+++ b/docs/cosi_driver/deployment.md
@@ -33,6 +33,7 @@ All parameters are mandatory and described below.
 | glcpUserSecretKey   | The HPE Green Lake API client secret.
 | dsccZone            | The fully qualified domain name (FQDN) of the HPE Data Services Cloud Console zone.
 | clusterSerialNumber | The backend storage system cluster serial number.
+| onPremCloudCA       | A Base64-encoded CA certificate for on-premise HPE Data Services Cloud Console deployments. Mandatory for on-premise (Deneb) setups where the DSCC instance uses a certificate signed by a private or non-public Certificate Authority.
 
 !!! note
     The Kubernetes compute nodes where the HPE COSI Driver is allowed to run need to be able to access the Data Services Cloud Console zone specified.
@@ -53,7 +54,12 @@ stringData:
   glcpUserSecretKey: 00000000000000000000000000000000
   dsccZone: us1.data.cloud.hpe.com
   clusterSerialNumber: 0000000000
+  # Required for on-premise (Deneb) deployments: Base64-encoded CA certificate
+  # onPremCloudCA: <base64-encoded-ca-certificate>
 ```
+
+!!! note
+    The `onPremCloudCA` parameter is mandatory for on-premise (Deneb) deployments. It must be omitted for cloud-hosted DSCC environments.
 
 Create the `Secret`.
 
@@ -79,11 +85,12 @@ kubectl create -f hpe-object-backend.yaml
     * Select the service that your HPE Alletra Storage MP X10000 device is assigned to and click _Launch_.
     * After the service is launched, save the value of the URL from the browser. E.g.: `https://console-us1.data.cloud.hpe.com`.
     * After dropping the prefix `https://console-`, the Data Services Cloud Console zone FQDN value to be used in the `Secret` should have the following format: `us1.data.cloud.hpe.com`.
-    * Supported Data Services Cloud Console zone FQDNs as of January 2025 are:
+    * Supported Data Services Cloud Console zone FQDNs as of April 2026 are:
         - us1.data.cloud.hpe.com
         - jp1.data.cloud.hpe.com
         - eu1.data.cloud.hpe.com
         - uk1.data.cloud.hpe.com
+        - uae1.data.cloud.hpe.com
 4. To locate the S3 endpoint:
     * Log into HPE Data Services Cloud Console.
     * Launch the service that your HPE Alletra Storage MP X10000 device is assigned to.
@@ -92,6 +99,9 @@ kubectl create -f hpe-object-backend.yaml
     * Click on the _Networking_ tab. Under the _Frontend Network_ section, save the value of the _Network DNS Subdomains_ field.
     * The S3 endpoint can be constructed from the _Network DNS Subdomains_ value by using the format: `http://<Network DNS Subdomains>`.
 5. To locate the cluster serial number of the HPE Alletra Storage MP X10000 system, refer to the following [HPE documentation](https://support.hpe.com/hpesc/public/docDisplay?docId=a00120892en_us&page=GUID-616CE4D4-C31A-4BFE-8F41-887C2B0B9046.html).
+6. To obtain the on-premise Cloud CA certificate (required for on-premise Deneb setups):
+    * Retrieve the CA certificate from the on-premise HPE Data Services Cloud Console instance being used.
+    * Encode the certificate in Base64 format and use the resulting value as the `onPremCloudCA` field in the `Secret`.
 
 !!! tip
     In a real world scenario it's more practical to name the `Secret` something that makes sense for the organization. It could be the hostname of the backend or the role it carries; i.e., "hpe-alletra-sanjose-prod".

--- a/docs/cosi_driver/deployment.md
+++ b/docs/cosi_driver/deployment.md
@@ -22,7 +22,7 @@ Once the COSI driver is deployed, you must create a `Secret` with the following 
 
 ### Secret Parameters
 
-All parameters are mandatory and described below.
+The following parameters are common to both cloud-hosted and on-premise (Deneb) DSCC deployments.
 
 | Parameter           | Description |
 | ------------------- | ------------|
@@ -34,12 +34,19 @@ All parameters are mandatory and described below.
 | dsccZone            | The fully qualified domain name (FQDN) of the HPE Data Services Cloud Console zone.
 | clusterSerialNumber | The backend storage system cluster serial number.
 
+The following parameters are deployment-specific.
+
+| Parameter           | Applies To   | Description |
+| ------------------- | ------------ | ------------|
+| glcpWorkspaceId     | Cloud only   | The HPE GreenLake workspace ID. Required for cloud-hosted DSCC deployments. Not applicable for on-premise (Deneb) deployments.
+| onPremCloudCA       | Deneb only   | A Base64-encoded CA certificate for the on-premise DSCC instance. Required when the DSCC CA certificate is not present in the cluster's trusted certificate store. If the CA certificate is already available in the cluster's truststore, this parameter can be omitted. Not applicable for cloud-hosted DSCC deployments.
+
 !!! note
     The Kubernetes compute nodes where the HPE COSI Driver is allowed to run need to be able to access the Data Services Cloud Console zone specified.
 
-Example `Secret` manifest named "hpe-object-backend.yaml":
+Example `Secret` manifest for a cloud-hosted DSCC deployment:
 
-```yaml fct_label="HPE COSI Driver v1.0.0"
+```yaml fct_label="Cloud"
 apiVersion: v1
 kind: Secret
 metadata:
@@ -51,8 +58,29 @@ stringData:
   endpoint: http://192.168.1.100:8080
   glcpUserClientId: 00000000-0000-0000-0000-000000000000
   glcpUserSecretKey: 00000000000000000000000000000000
+  glcpWorkspaceId: 00000000000000000000000000000000
   dsccZone: us1.data.cloud.hpe.com
   clusterSerialNumber: 0000000000
+```
+
+Example `Secret` manifest for an on-premise (Deneb) DSCC deployment:
+
+```yaml fct_label="Deneb (On-Premise)"
+apiVersion: v1
+kind: Secret
+metadata:
+  name: hpe-object-backend
+  namespace: default
+stringData:
+  accessKey: testuser
+  secretKey: testkey
+  endpoint: http://192.168.1.100:8080
+  glcpUserClientId: 00000000-0000-0000-0000-000000000000
+  glcpUserSecretKey: 00000000000000000000000000000000
+  dsccZone: dscc-api.example.lab.nimblestorage.com
+  clusterSerialNumber: 0000000000
+  # Optional: include if the DSCC CA certificate is not in the cluster's truststore
+  # onPremCloudCA: <base64-encoded-ca-certificate>
 ```
 
 Create the `Secret`.
@@ -79,11 +107,12 @@ kubectl create -f hpe-object-backend.yaml
     * Select the service that your HPE Alletra Storage MP X10000 device is assigned to and click _Launch_.
     * After the service is launched, save the value of the URL from the browser. E.g.: `https://console-us1.data.cloud.hpe.com`.
     * After dropping the prefix `https://console-`, the Data Services Cloud Console zone FQDN value to be used in the `Secret` should have the following format: `us1.data.cloud.hpe.com`.
-    * Supported Data Services Cloud Console zone FQDNs as of January 2025 are:
+    * Supported Data Services Cloud Console zone FQDNs as of April 2026 are:
         - us1.data.cloud.hpe.com
         - jp1.data.cloud.hpe.com
         - eu1.data.cloud.hpe.com
         - uk1.data.cloud.hpe.com
+        - uae1.data.cloud.hpe.com
 4. To locate the S3 endpoint:
     * Log into HPE Data Services Cloud Console.
     * Launch the service that your HPE Alletra Storage MP X10000 device is assigned to.
@@ -92,6 +121,9 @@ kubectl create -f hpe-object-backend.yaml
     * Click on the _Networking_ tab. Under the _Frontend Network_ section, save the value of the _Network DNS Subdomains_ field.
     * The S3 endpoint can be constructed from the _Network DNS Subdomains_ value by using the format: `http://<Network DNS Subdomains>`.
 5. To locate the cluster serial number of the HPE Alletra Storage MP X10000 system, refer to the following [HPE documentation](https://support.hpe.com/hpesc/public/docDisplay?docId=a00120892en_us&page=GUID-616CE4D4-C31A-4BFE-8F41-887C2B0B9046.html).
+6. To obtain the on-premise Cloud CA certificate (required for on-premise Deneb setups):
+    * Retrieve the CA certificate from the on-premise HPE Data Services Cloud Console instance being used.
+    * Encode the certificate in Base64 format and use the resulting value as the `onPremCloudCA` field in the `Secret`.
 
 !!! tip
     In a real world scenario it's more practical to name the `Secret` something that makes sense for the organization. It could be the hostname of the backend or the role it carries; i.e., "hpe-alletra-sanjose-prod".

--- a/docs/cosi_driver/using.md
+++ b/docs/cosi_driver/using.md
@@ -42,6 +42,11 @@ Optional `BucketClass` `.parameters`.
 | Parameter                     | String         | Description |
 | ----------------------------- | -------------- | ----------- |
 | bucketTags                    | Text           | The tags to be applied on a bucket. The key-value pairs must be comma separated. In a tag, the key is required while the value is optional. Example: `.parameters.bucketTags: mytag1=myval1, mytag2, mytag3=myval3`. |
+| compression                   | Text           | Enable bucket compression. The only accepted value is `Enabled` (case-insensitive). Defaults to `Disabled` if not specified. Example: `.parameters.compression: Enabled`. |
+| versioning                    | Text           | Enable bucket versioning. The only accepted value is `Enabled` (case-insensitive). Defaults to `Disabled` if not specified. Example: `.parameters.versioning: Enabled`. |
+| locking                       | Text           | Enable object locking on the bucket. The only accepted value is `Enabled` (case-insensitive). Requires `versioning` to be `Enabled`. Example: `.parameters.locking: Enabled`. |
+| retentionMode                 | Text           | The default retention mode for object locking. Accepted values are `COMPLIANCE` or `GOVERNANCE`. Only applicable when `locking` is `Enabled`. Example: `.parameters.retentionMode: COMPLIANCE`. |
+| defaultRetentionInterval      | Text           | The default retention duration for object locking. Format is `<number><unit>` where unit is `d` for days, `m` for months (treated as 30 days), or `y` for years. Only applicable when `locking` is `Enabled`. Example: `.parameters.defaultRetentionInterval: 30d`. |
 
 ## Create a BucketClaim
 


### PR DESCRIPTION
- Add BucketClass optional parameters: versioning, locking, retentionMode, defaultRetentionInterval
- Add onPremCloudCA Secret parameter for on-premise (Deneb) DSCC deployments
- Add step 6 under Creating and Locating Resources for obtaining the on-premise CA certificate
- Update example Secret manifest with onPremCloudCA field and clarifying note
- Updated Supported Data Services Cloud Console zone