### PR TITLE
Add v3.storage.hpe.com to OpenShift APIServices list

### DIFF
--- a/docs/csi_driver/partners/redhat_openshift/index.md
+++ b/docs/csi_driver/partners/redhat_openshift/index.md
@@ -255,6 +255,7 @@ The following are `APIServices` installed by the HPE CSI Driver.
 ```text
 v1.storage.hpe.com
 v2.storage.hpe.com
+v3.storage.hpe.com
 ```
 
 Please refer to the OLM Lifecycle Manager documentation on how to safely [Uninstall your operator](https://olm.operatorframework.io/docs/tasks/uninstall-operator/).


### PR DESCRIPTION
Fixes #296

The `hpereplicationmappings.storage.hpe.com` CRD [serves version v3](https://github.com/hpe-storage/co-deployments/blob/06b2e3dde049577e7b7f7c5e65ff2c77c01cd981/helm/charts/hpe-csi-driver/crds/storage.hpe.com_hpereplicationmappings.yaml#L18) under the `storage.hpe.com` API group, creating the `v3.storage.hpe.com` APIService on install. The documentation was missing this entry.