### PR TITLE
Add HPE COSI Driver R2 (v2.0.0) documentation and release versioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ site/
 docs/sandbox
 **/*.tmp
 **/*.swp
+.venv/

--- a/docs/cosi_driver/deployment.md
+++ b/docs/cosi_driver/deployment.md
@@ -37,7 +37,7 @@ The following parameters are common to both cloud-hosted and on-premise (Deneb) 
 | dsccZone            | The fully qualified domain name (FQDN) of the HPE Data Services Cloud Console zone.For on-premise (Deneb) deployments, prefix the instance hostname with `dscc-api-`.
 | clusterSerialNumber | The backend storage system cluster serial number.
 
-The following parameters are deployment-specific.
+The following parameters are deployment-specific and are applicable only to COSI 2.0.0. They are not applicable to COSI 1.0.0 and can be ignored when using that release.
 
 | Parameter           | Applies To   | Description |
 | ------------------- | ------------ | ------------|
@@ -86,6 +86,24 @@ stringData:
   # onPremCloudCA: <base64-encoded-ca-certificate>
 ```
 
+Example `Secret` manifest for the HPE COSI Driver v1.0.0.0:
+
+```yaml fct_label="Release 1 (v1.0.0)"
+apiVersion: v1
+kind: Secret
+metadata:
+  name: hpe-object-backend
+  namespace: default
+stringData:
+  accessKey: testuser
+  secretKey: testkey
+  endpoint: http://192.168.1.100:8080
+  glcpUserClientId: 00000000-0000-0000-0000-000000000000
+  glcpUserSecretKey: 00000000000000000000000000000000
+  dsccZone: us1.data.cloud.hpe.com
+  clusterSerialNumber: 0000000000
+```
+
 Create the `Secret`.
 
 ```text
@@ -125,9 +143,13 @@ kubectl create -f hpe-object-backend.yaml
     * Click on the _Networking_ tab. Under the _Frontend Network_ section, save the value of the _Network DNS Subdomains_ field.
     * The S3 endpoint can be constructed from the _Network DNS Subdomains_ value by using the format: `http://<Network DNS Subdomains>`.
 5. To locate the cluster serial number of the HPE Alletra Storage MP X10000 system, refer to the following [HPE documentation](https://support.hpe.com/hpesc/public/docDisplay?docId=a00120892en_us&page=GUID-616CE4D4-C31A-4BFE-8F41-887C2B0B9046.html).
-6. To view the workspace ID and manage the workspace, refer to the following [HPE documentation](https://support.hpe.com/hpesc/public/docDisplay?docId=a00120892en_us&page=GUID-D62EE4D7-5CBF-43A0-B91B-12A07EC3D262.html).
+6. To view the workspace ID and manage the workspace (required for on-cloud DSCC setups):
+    * Log into the HPE Data Services Cloud Console UI.
+    * Navigate to _Quick links_ &rarr; _Manage Workspace_.
+    * The _Workspace ID_ is displayed on the page and is used as the `glcpWorkspaceId` field in the `Secret`.
+    * For more details, refer to the [Manage workspace](https://support.hpe.com/hpesc/public/docDisplay?docId=sd00005271en_us&page=GUID-DD8699BF-D17E-4A1C-863A-AE7ED0AA8C88.html) documentation.
 7. To obtain the on-premise Cloud CA certificate (required for on-premise Deneb setups):
-    * Retrieve the CA certificate from the on-premise HPE Data Services Cloud Console instance being used.
+    * Retrieve the CA certificate from the on-premise HPE Data Services Cloud Console instance being used. For the download steps, refer to the [Downloading your CA certificates](https://support.hpe.com/hpesc/public/docDisplay?docId=sd00005271en_us&page=GUID-F0ADEE0C-7BB5-4010-B290-FF700A6B7878.html) documentation.
     * Encode the certificate in Base64 format and use the resulting value as the `onPremCloudCA` field in the `Secret`.
 
 !!! tip

--- a/docs/cosi_driver/deployment.md
+++ b/docs/cosi_driver/deployment.md
@@ -16,6 +16,9 @@ The official [Helm chart](https://github.com/hpe-storage/co-deployments/tree/mas
 
 - Go to the chart on [Artifact Hub](https://artifacthub.io/packages/helm/hpe-storage/hpe-cosi-driver).
 
+!!! note "On-Premise (Deneb) Deployments"
+    When deploying against an on-premise DSCC instance, the `glcpCommonCloud` Helm chart value must be set with the `sso-` prefix before the instance hostname.
+
 ## Add an HPE Storage Backend
 
 Once the COSI driver is deployed, you must create a `Secret` with the following details before you can use the [COSI API resources](using.md).
@@ -31,7 +34,7 @@ The following parameters are common to both cloud-hosted and on-premise (Deneb) 
 | endpoint            | The S3 frontend network DNS subdomains address of the backend object storage system; that is, an HPE Alletra Storage MP X10000 system.
 | glcpUserClientId    | The HPE Green Lake API client ID.
 | glcpUserSecretKey   | The HPE Green Lake API client secret.
-| dsccZone            | The fully qualified domain name (FQDN) of the HPE Data Services Cloud Console zone.
+| dsccZone            | The fully qualified domain name (FQDN) of the HPE Data Services Cloud Console zone.For on-premise (Deneb) deployments, prefix the instance hostname with `dscc-api-`.
 | clusterSerialNumber | The backend storage system cluster serial number.
 
 The following parameters are deployment-specific.

--- a/docs/cosi_driver/deployment.md
+++ b/docs/cosi_driver/deployment.md
@@ -143,14 +143,16 @@ kubectl create -f hpe-object-backend.yaml
     * Click on the _Networking_ tab. Under the _Frontend Network_ section, save the value of the _Network DNS Subdomains_ field.
     * The S3 endpoint can be constructed from the _Network DNS Subdomains_ value by using the format: `http://<Network DNS Subdomains>`.
 5. To locate the cluster serial number of the HPE Alletra Storage MP X10000 system, refer to the following [HPE documentation](https://support.hpe.com/hpesc/public/docDisplay?docId=a00120892en_us&page=GUID-616CE4D4-C31A-4BFE-8F41-887C2B0B9046.html).
-6. To view the workspace ID and manage the workspace (required for on-cloud DSCC setups):
+6. \* To view the workspace ID and manage the workspace (required for on-cloud DSCC setups):
     * Log into the HPE Data Services Cloud Console UI.
     * Navigate to _Quick links_ &rarr; _Manage Workspace_.
     * The _Workspace ID_ is displayed on the page and is used as the `glcpWorkspaceId` field in the `Secret`.
     * For more details, refer to the [Manage workspace](https://support.hpe.com/hpesc/public/docDisplay?docId=sd00005271en_us&page=GUID-DD8699BF-D17E-4A1C-863A-AE7ED0AA8C88.html) documentation.
-7. To obtain the on-premise Cloud CA certificate (required for on-premise Deneb setups):
+7. \* To obtain the on-premise Cloud CA certificate (required for on-premise Deneb setups):
     * Retrieve the CA certificate from the on-premise HPE Data Services Cloud Console instance being used. For the download steps, refer to the [Downloading your CA certificates](https://support.hpe.com/hpesc/public/docDisplay?docId=sd00005271en_us&page=GUID-F0ADEE0C-7BB5-4010-B290-FF700A6B7878.html) documentation.
     * Encode the certificate in Base64 format and use the resulting value as the `onPremCloudCA` field in the `Secret`.
+
+<small>\* Applicable only from the HPE COSI Driver for Kubernetes v2.0.0 onwards. These steps are not applicable to v1.0.0.</small>
 
 !!! tip
     In a real world scenario it's more practical to name the `Secret` something that makes sense for the organization. It could be the hostname of the backend or the role it carries; i.e., "hpe-alletra-sanjose-prod".

--- a/docs/cosi_driver/deployment.md
+++ b/docs/cosi_driver/deployment.md
@@ -22,7 +22,7 @@ Once the COSI driver is deployed, you must create a `Secret` with the following 
 
 ### Secret Parameters
 
-All parameters are mandatory and described below.
+The following parameters are common to both cloud-hosted and on-premise (Deneb) DSCC deployments.
 
 | Parameter           | Description |
 | ------------------- | ------------|
@@ -34,12 +34,19 @@ All parameters are mandatory and described below.
 | dsccZone            | The fully qualified domain name (FQDN) of the HPE Data Services Cloud Console zone.
 | clusterSerialNumber | The backend storage system cluster serial number.
 
+The following parameters are deployment-specific.
+
+| Parameter           | Applies To   | Description |
+| ------------------- | ------------ | ------------|
+| glcpWorkspaceId     | Cloud only   | The HPE GreenLake workspace ID. Required for cloud-hosted DSCC deployments. Not applicable for on-premise (Deneb) deployments.
+| onPremCloudCA       | Deneb only   | A Base64-encoded CA certificate for the on-premise DSCC instance. Required when the DSCC CA certificate is not present in the cluster's trusted certificate store. If the CA certificate is already available in the cluster's truststore, this parameter can be omitted. Not applicable for cloud-hosted DSCC deployments.
+
 !!! note
     The Kubernetes compute nodes where the HPE COSI Driver is allowed to run need to be able to access the Data Services Cloud Console zone specified.
 
-Example `Secret` manifest named "hpe-object-backend.yaml":
+Example `Secret` manifest for a cloud-hosted DSCC deployment:
 
-```yaml fct_label="HPE COSI Driver v1.0.0"
+```yaml fct_label="Cloud"
 apiVersion: v1
 kind: Secret
 metadata:
@@ -51,8 +58,29 @@ stringData:
   endpoint: http://192.168.1.100:8080
   glcpUserClientId: 00000000-0000-0000-0000-000000000000
   glcpUserSecretKey: 00000000000000000000000000000000
+  glcpWorkspaceId: 00000000000000000000000000000000
   dsccZone: us1.data.cloud.hpe.com
   clusterSerialNumber: 0000000000
+```
+
+Example `Secret` manifest for an on-premise (Deneb) DSCC deployment:
+
+```yaml fct_label="Deneb (On-Premise)"
+apiVersion: v1
+kind: Secret
+metadata:
+  name: hpe-object-backend
+  namespace: default
+stringData:
+  accessKey: testuser
+  secretKey: testkey
+  endpoint: http://192.168.1.100:8080
+  glcpUserClientId: 00000000-0000-0000-0000-000000000000
+  glcpUserSecretKey: 00000000000000000000000000000000
+  dsccZone: dscc-api.example.lab.nimblestorage.com
+  clusterSerialNumber: 0000000000
+  # Optional: include if the DSCC CA certificate is not in the cluster's truststore
+  # onPremCloudCA: <base64-encoded-ca-certificate>
 ```
 
 Create the `Secret`.
@@ -79,11 +107,13 @@ kubectl create -f hpe-object-backend.yaml
     * Select the service that your HPE Alletra Storage MP X10000 device is assigned to and click _Launch_.
     * After the service is launched, save the value of the URL from the browser. E.g.: `https://console-us1.data.cloud.hpe.com`.
     * After dropping the prefix `https://console-`, the Data Services Cloud Console zone FQDN value to be used in the `Secret` should have the following format: `us1.data.cloud.hpe.com`.
-    * Supported Data Services Cloud Console zone FQDNs as of January 2025 are:
+    * Supported Data Services Cloud Console zone FQDNs as of June 2026 are:
         - us1.data.cloud.hpe.com
         - jp1.data.cloud.hpe.com
         - eu1.data.cloud.hpe.com
         - uk1.data.cloud.hpe.com
+        - uae1.data.cloud.hpe.com
+    * For the latest list of supported zones, refer to the [HPE documentation](https://support.hpe.com/hpesc/public/docDisplay?docId=sd00007065en_us&page=GUID-D6312444-1C1A-434D-A0D7-986DEF6FFCEB.html&docLocale=en_US#ariaid-title1).
 4. To locate the S3 endpoint:
     * Log into HPE Data Services Cloud Console.
     * Launch the service that your HPE Alletra Storage MP X10000 device is assigned to.
@@ -92,6 +122,10 @@ kubectl create -f hpe-object-backend.yaml
     * Click on the _Networking_ tab. Under the _Frontend Network_ section, save the value of the _Network DNS Subdomains_ field.
     * The S3 endpoint can be constructed from the _Network DNS Subdomains_ value by using the format: `http://<Network DNS Subdomains>`.
 5. To locate the cluster serial number of the HPE Alletra Storage MP X10000 system, refer to the following [HPE documentation](https://support.hpe.com/hpesc/public/docDisplay?docId=a00120892en_us&page=GUID-616CE4D4-C31A-4BFE-8F41-887C2B0B9046.html).
+6. To view the workspace ID and manage the workspace, refer to the following [HPE documentation](https://support.hpe.com/hpesc/public/docDisplay?docId=a00120892en_us&page=GUID-D62EE4D7-5CBF-43A0-B91B-12A07EC3D262.html).
+7. To obtain the on-premise Cloud CA certificate (required for on-premise Deneb setups):
+    * Retrieve the CA certificate from the on-premise HPE Data Services Cloud Console instance being used.
+    * Encode the certificate in Base64 format and use the resulting value as the `onPremCloudCA` field in the `Secret`.
 
 !!! tip
     In a real world scenario it's more practical to name the `Secret` something that makes sense for the organization. It could be the hostname of the backend or the role it carries; i.e., "hpe-alletra-sanjose-prod".

--- a/docs/cosi_driver/index.md
+++ b/docs/cosi_driver/index.md
@@ -17,11 +17,11 @@ Below is the official table for COSI features that HPE has officially tested and
 
 | Feature                                | K8s maturity | Since K8s version | HPE COSI Driver |
 |----------------------------------------|--------------|-------------------|-----------------|
-| Bucket Creation                        | Alpha        | 1.36              | 2.0.0           |
-| Bucket Deletion                        | Alpha        | 1.36              | 2.0.0           |
-| Bucket Tagging                         | Alpha        | 1.36              | 2.0.0           |
-| Granting Bucket Access                 | Alpha        | 1.36              | 2.0.0           |
-| Revoking Bucket Access                 | Alpha        | 1.36              | 2.0.0           |
+| Bucket Creation                        | v1alpha1     | 1.36              | 2.0.0           |
+| Bucket Deletion                        | v1alpha1     | 1.36              | 2.0.0           |
+| Bucket Tagging                         | v1alpha1     | 1.36              | 2.0.0           |
+| Granting Bucket Access                 | v1alpha1     | 1.36              | 2.0.0           |
+| Revoking Bucket Access                 | v1alpha1     | 1.36              | 2.0.0           |
 
 Refer to the [official table](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/) of feature gates in the Kubernetes docs to determine the availability of alpha features. File any issues, questions or feature requests [here](https://github.com/hpe-storage/cosi-driver/issues). You may also join the HPE Slack community to chat with people close to this project on the `#Alletra` and `#Kubernetes` channels. Sign up at [slack.hpedev.io](https://slack.hpedev.io/) and log in at [hpedev.slack.com](https://hpedev.slack.com).
 
@@ -82,6 +82,7 @@ HPE does not currently have any archived releases of the HPE COSI Driver.
 
 ## Known Limitations
 
+* BucketClaim and Bucket Access related events are observed to be generated under the default namespace, regardless of whether the deployment is running in a non-default namespace.
 * Creating `BucketClaim` or `BucketAccess` objects in parallel can cause failures in the COSI driver. A [bug](https://github.com/kubernetes-sigs/container-object-storage-interface-api/issues/101) has been filed to address this issue.
 * A warning event is created in the `Bucket` or `BucketAccess` resources when an error occurs, and has a life-span of one hour. During this period, if the error is resolved the Status will show `Bucket Ready: true` or `Access Granted: true` in the `Bucket` or `BucketAccess` respectively, but the warning event will persist till an hour lapses. A [bug](https://github.com/kubernetes-sigs/container-object-storage-interface-api/issues/103) has been raised to resolve this ambiguity.
 * Recreation of `BucketClaim` or `BucketAccess` objects doesn't work intermittently, as gRPC request is not sent to the COSI driver. This [pull request](https://github.com/kubernetes-retired/container-object-storage-interface-api/pull/86) will address the issue.

--- a/docs/cosi_driver/index.md
+++ b/docs/cosi_driver/index.md
@@ -63,7 +63,7 @@ Release highlights:
   <tr>
     <th>HPE Alletra Storage MP X10000 OS</th>
     <td>
-      R1
+      R1, R2, R3
     </td>
   </tr>
   <tr>
@@ -73,6 +73,45 @@ Release highlights:
   <tr>
     <th>Release&nbsp;notes</th>
     <td><a href="https://github.com/hpe-storage/cosi-driver/tree/main/release-notes/v1.0.0.md">v2.0.0</a> on GitHub</td>
+  </tr>
+</table>
+
+### HPE COSI Driver for Kubernetes v1.0.0
+
+Release highlights:
+
+* Support for Kubernetes v1.25 to v1.31.
+* Implementation of bucket creation, configuration (bucket tagging), lifecycle and access management.
+* A log collector script that can be used to collect logs from any node.
+
+<table>
+  <tr>
+    <th>Kubernetes</th>
+    <td>v1.25-v1.31</td>
+  </tr>
+  <tr>
+    <th>Helm Chart</th>
+    <td><a href="https://artifacthub.io/packages/helm/hpe-storage/hpe-cosi-driver/1.0.0">v1.0.0</a> on ArtifactHub</td>
+  </tr>
+  <tr>
+    <th>Platforms</th>
+    <td>
+      HPE Alletra Storage MP X10000
+    </td>
+  </tr>
+  <tr>
+    <th>HPE Alletra Storage MP X10000 OS</th>
+    <td>
+      R1
+    </td>
+  </tr>
+  <tr>
+    <th>Protocols</th>
+    <td>S3</td>
+  </tr>
+  <tr>
+    <th>Release&nbsp;notes</th>
+    <td><a href="https://github.com/hpe-storage/cosi-driver/tree/main/release-notes/v1.0.0.md">v1.0.0</a> on GitHub</td>
   </tr>
 </table>
 

--- a/docs/cosi_driver/index.md
+++ b/docs/cosi_driver/index.md
@@ -51,6 +51,10 @@ Release highlights:
     <td><a href="https://artifacthub.io/packages/helm/hpe-storage/hpe-cosi-driver/1.0.0">v1.0.0</a> on ArtifactHub</td>
   </tr>
   <tr>
+    <th>OpenShift</th>
+    <td>v4.21+</td>
+  </tr>
+  <tr>
     <th>Platforms</th>
     <td>
       HPE Alletra Storage MP X10000
@@ -78,7 +82,6 @@ HPE does not currently have any archived releases of the HPE COSI Driver.
 
 ## Known Limitations
 
-* The HPE COSI driver can be deployed only in the `default` namespace due to a [bug](https://github.com/kubernetes-sigs/container-object-storage-interface-provisioner-sidecar/issues/140) in creating events in the COSI API objects when deployed in non-default namespaces.
 * Creating `BucketClaim` or `BucketAccess` objects in parallel can cause failures in the COSI driver. A [bug](https://github.com/kubernetes-sigs/container-object-storage-interface-api/issues/101) has been filed to address this issue.
 * A warning event is created in the `Bucket` or `BucketAccess` resources when an error occurs, and has a life-span of one hour. During this period, if the error is resolved the Status will show `Bucket Ready: true` or `Access Granted: true` in the `Bucket` or `BucketAccess` respectively, but the warning event will persist till an hour lapses. A [bug](https://github.com/kubernetes-sigs/container-object-storage-interface-api/issues/103) has been raised to resolve this ambiguity.
 * Recreation of `BucketClaim` or `BucketAccess` objects doesn't work intermittently, as gRPC request is not sent to the COSI driver. This [pull request](https://github.com/kubernetes-retired/container-object-storage-interface-api/pull/86) will address the issue.

--- a/docs/cosi_driver/index.md
+++ b/docs/cosi_driver/index.md
@@ -17,11 +17,11 @@ Below is the official table for COSI features that HPE has officially tested and
 
 | Feature                                | K8s maturity | Since K8s version | HPE COSI Driver |
 |----------------------------------------|--------------|-------------------|-----------------|
-| Bucket Creation                        | Alpha        | 1.25              | 1.0.0           |
-| Bucket Deletion                        | Alpha        | 1.25              | 1.0.0           |
-| Bucket Tagging                         | Alpha        | 1.25              | 1.0.0           |
-| Granting Bucket Access                 | Alpha        | 1.25              | 1.0.0           |
-| Revoking Bucket Access                 | Alpha        | 1.25              | 1.0.0           |
+| Bucket Creation                        | Alpha        | 1.36              | 2.0.0           |
+| Bucket Deletion                        | Alpha        | 1.36              | 2.0.0           |
+| Bucket Tagging                         | Alpha        | 1.36              | 2.0.0           |
+| Granting Bucket Access                 | Alpha        | 1.36              | 2.0.0           |
+| Revoking Bucket Access                 | Alpha        | 1.36              | 2.0.0           |
 
 Refer to the [official table](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/) of feature gates in the Kubernetes docs to determine the availability of alpha features. File any issues, questions or feature requests [here](https://github.com/hpe-storage/cosi-driver/issues). You may also join the HPE Slack community to chat with people close to this project on the `#Alletra` and `#Kubernetes` channels. Sign up at [slack.hpedev.io](https://slack.hpedev.io/) and log in at [hpedev.slack.com](https://hpedev.slack.com).
 
@@ -33,26 +33,26 @@ Refer to the [official table](https://kubernetes.io/docs/reference/command-line-
 HPE has tested the following combinations and included them as part of the official support services for the first COSI driver release.
 
 <a name="latest_release"></a>
-### HPE COSI Driver for Kubernetes v1.0.0
+### HPE COSI Driver for Kubernetes v2.0.0
 
 Release highlights:
 
-* Support for Kubernetes v1.25 to v1.31.
+* Support for Kubernetes v1.25 to v1.36.
 * Implementation of bucket creation, configuration (bucket tagging), lifecycle and access management.
 * A log collector script that can be used to collect logs from any node.
 
 <table>
   <tr>
     <th>Kubernetes</th>
-    <td>v1.25-v1.31</td>
+    <td>v1.25-v1.36</td>
   </tr>
   <tr>
     <th>Helm Chart</th>
-    <td><a href="https://artifacthub.io/packages/helm/hpe-storage/hpe-cosi-driver/1.0.0">v1.0.0</a> on ArtifactHub</td>
+    <td><a href="https://artifacthub.io/packages/helm/hpe-storage/hpe-cosi-driver/1.0.0">v2.0.0</a> on ArtifactHub</td>
   </tr>
   <tr>
     <th>OpenShift</th>
-    <td>v4.21+</td>
+    <td>v4.19–v4.21</td>
   </tr>
   <tr>
     <th>Platforms</th>
@@ -72,7 +72,7 @@ Release highlights:
   </tr>
   <tr>
     <th>Release&nbsp;notes</th>
-    <td><a href="https://github.com/hpe-storage/cosi-driver/tree/main/release-notes/v1.0.0.md">v1.0.0</a> on GitHub</td>
+    <td><a href="https://github.com/hpe-storage/cosi-driver/tree/main/release-notes/v1.0.0.md">v2.0.0</a> on GitHub</td>
   </tr>
 </table>
 

--- a/docs/cosi_driver/index.md
+++ b/docs/cosi_driver/index.md
@@ -52,7 +52,7 @@ Release highlights:
   </tr>
   <tr>
     <th>OpenShift</th>
-    <td>v4.19–v4.21</td>
+    <td>v4.19-v4.21</td>
   </tr>
   <tr>
     <th>Platforms</th>

--- a/docs/cosi_driver/using.md
+++ b/docs/cosi_driver/using.md
@@ -11,7 +11,22 @@ At this point the HPE COSI Driver and HPE Alletra Storage MP X10000 should be in
 
 The `BucketClass` defines a set of properties that can be used to configure buckets. The `BucketClass` has a variety of fields that you can configure. An example of `BucketClass` is below. `BucketClasses` are clustered resources normally created by Kubernetes administrators.
 
-```yaml
+```yaml fct_label="Release 2 (v2.0.0)"
+kind: BucketClass
+apiVersion: objectstorage.k8s.io/v1alpha1
+metadata:
+  name: hpe-standard-object
+driverName: cosi.hpe.com
+deletionPolicy: Delete
+parameters:
+  cosiUserSecretName: hpe-object-backend
+  cosiUserSecretNamespace: default
+  compression: Enabled
+  versioning: Enabled
+  locking: Enabled
+```
+
+```yaml fct_label="Release 1 (v1.0.0)"
 kind: BucketClass
 apiVersion: objectstorage.k8s.io/v1alpha1
 metadata:

--- a/docs/cosi_driver/using.md
+++ b/docs/cosi_driver/using.md
@@ -39,14 +39,14 @@ kubectl create -f hpe-standard-object.yaml
 
 Optional `BucketClass` `.parameters`.
 
-| Parameter                     | String         | Description |
-| ----------------------------- | -------------- | ----------- |
-| bucketTags                    | Text           | The tags to be applied on a bucket. The key-value pairs must be comma separated. In a tag, the key is required while the value is optional. Example: `.parameters.bucketTags: mytag1=myval1, mytag2, mytag3=myval3`. |
-| compression                   | Text           | Enable bucket compression. Accepted values are `Enabled` \| `Disabled` (case-insensitive). Defaults to `Disabled` if not specified. Example: `.parameters.compression: Enabled`. |
-| versioning                    | Text           | Enable bucket versioning. Accepted values are `Enabled` \| `Disabled` (case-insensitive). Defaults to `Disabled` if not specified. Example: `.parameters.versioning: Enabled`. |
-| locking                       | Text           | Enable object locking on the bucket. The only accepted value is `Enabled` (case-insensitive). Requires `versioning` to be `Enabled`. Example: `.parameters.locking: Enabled`. |
-| retentionMode                 | Text           | The default retention mode for object locking. Accepted values are `COMPLIANCE` or `GOVERNANCE`. Only applicable when `locking` is `Enabled`. Example: `.parameters.retentionMode: COMPLIANCE`. |
-| defaultRetentionInterval      | Text           | The default retention duration for object locking. Format is `<number><unit>` where unit is `d` for days, `m` for months (treated as 30 days), or `y` for years. Only applicable when `locking` is `Enabled`. Example: `.parameters.defaultRetentionInterval: 30d`. |
+| Parameter                     | String         | Release  | Description |
+| ----------------------------- | -------------- | -------- | ----------- |
+| bucketTags                    | Text           | v1.0.0   | The tags to be applied on a bucket. The key-value pairs must be comma separated. In a tag, the key is required while the value is optional. Example: `.parameters.bucketTags: mytag1=myval1, mytag2, mytag3=myval3`. |
+| compression                   | Text           | v2.0.0   | Enable bucket compression. Accepted values are `Enabled` \| `Disabled` (case-insensitive). Defaults to `Disabled` if not specified. Example: `.parameters.compression: Enabled`. |
+| versioning                    | Text           | v2.0.0   | Enable bucket versioning. Accepted values are `Enabled` \| `Disabled` (case-insensitive). Defaults to `Disabled` if not specified. Example: `.parameters.versioning: Enabled`. |
+| locking                       | Text           | v2.0.0   | Enable object locking on the bucket. The only accepted value is `Enabled` (case-insensitive). Requires `versioning` to be `Enabled`. Example: `.parameters.locking: Enabled`. |
+| retentionMode                 | Text           | v2.0.0   | The default retention mode for object locking. Accepted values are `COMPLIANCE` or `GOVERNANCE`. Only applicable when `locking` is `Enabled`. Example: `.parameters.retentionMode: COMPLIANCE`. |
+| defaultRetentionInterval      | Text           | v2.0.0   | The default retention duration for object locking. Format is `<number><unit>` where unit is `d` for days, `m` for months (treated as 30 days), or `y` for years. Only applicable when `locking` is `Enabled`. Example: `.parameters.defaultRetentionInterval: 30d`. |
 
 ## Create a BucketClaim
 

--- a/docs/cosi_driver/using.md
+++ b/docs/cosi_driver/using.md
@@ -42,6 +42,11 @@ Optional `BucketClass` `.parameters`.
 | Parameter                     | String         | Description |
 | ----------------------------- | -------------- | ----------- |
 | bucketTags                    | Text           | The tags to be applied on a bucket. The key-value pairs must be comma separated. In a tag, the key is required while the value is optional. Example: `.parameters.bucketTags: mytag1=myval1, mytag2, mytag3=myval3`. |
+| compression                   | Text           | Enable bucket compression. Accepted values are `Enabled` \| `Disabled` (case-insensitive). Defaults to `Disabled` if not specified. Example: `.parameters.compression: Enabled`. |
+| versioning                    | Text           | Enable bucket versioning. Accepted values are `Enabled` \| `Disabled` (case-insensitive). Defaults to `Disabled` if not specified. Example: `.parameters.versioning: Enabled`. |
+| locking                       | Text           | Enable object locking on the bucket. The only accepted value is `Enabled` (case-insensitive). Requires `versioning` to be `Enabled`. Example: `.parameters.locking: Enabled`. |
+| retentionMode                 | Text           | The default retention mode for object locking. Accepted values are `COMPLIANCE` or `GOVERNANCE`. Only applicable when `locking` is `Enabled`. Example: `.parameters.retentionMode: COMPLIANCE`. |
+| defaultRetentionInterval      | Text           | The default retention duration for object locking. Format is `<number><unit>` where unit is `d` for days, `m` for months (treated as 30 days), or `y` for years. Only applicable when `locking` is `Enabled`. Example: `.parameters.defaultRetentionInterval: 30d`. |
 
 ## Create a BucketClaim
 


### PR DESCRIPTION
Updated the HPE COSI Driver for Kubernetes documentation to cover the Release 2 (v2.0.0) alongside the existing Release 1 (v1.0.0), following the release/versioning convention used by the HPE SCOD.